### PR TITLE
VOYAGE-46 Add tests to check if service starts

### DIFF
--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -1,0 +1,39 @@
+name: Docker Compose Test
+
+on:
+  pull_request:
+    branches: [ main, dev]
+
+jobs:
+  test-docker-compose:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Install Docker Compose
+      run: |
+        sudo curl -L "https://github.com/docker/compose/releases/download/v2.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        sudo chmod +x /usr/local/bin/docker-compose
+        docker-compose --version
+
+    - name: Docker Compose Test
+      run: |
+        chmod +x ./test-docker-compose.sh
+        ./test-docker-compose.sh
+
+    - name: Upload logs if failure
+      if: failure()
+      run: |
+        docker-compose logs > docker-compose-logs.txt
+
+    - name: Archive logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-compose-logs
+        path: docker-compose-logs.txt

--- a/test-docker-compose.sh
+++ b/test-docker-compose.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Test script to verify Docker Compose setup
+# Designed to run in CI/CD pipelines (e.g., GitHub Actions)
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+echo "==== Docker Compose Test Script ===="
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}Error: Docker is not installed.${NC}"
+    exit 1
+fi
+
+# Check if Docker Compose is installed
+if ! command -v docker-compose &> /dev/null; then
+    echo -e "${RED}Error: Docker Compose is not installed.${NC}"
+    exit 1
+fi
+
+# Check if docker-compose.yml exists in current directory
+if [ ! -f "docker-compose.yaml" ]; then
+    echo -e "${RED}Error: docker-compose.yaml not found in current directory.${NC}"
+    exit 1
+fi
+
+echo -e "${YELLOW}Starting Docker Compose...${NC}"
+docker-compose down -v &> /dev/null # Clean up any existing containers
+docker-compose up -d
+
+# Wait for containers to start (adjust timeout as needed for your services)
+echo -e "${YELLOW}Waiting for containers to initialize...${NC}"
+sleep 10
+
+# Get list of services from docker-compose.yml
+SERVICES=$(docker-compose config --services)
+
+# Check if all services are running
+ALL_RUNNING=true
+for SERVICE in $SERVICES; do
+    STATUS=$(docker-compose ps -q $SERVICE)
+    if [ -z "$STATUS" ]; then
+        echo -e "${RED}❌ Service $SERVICE is not running${NC}"
+        ALL_RUNNING=false
+    else
+        CONTAINER_STATUS=$(docker inspect --format='{{.State.Status}}' $STATUS)
+        if [ "$CONTAINER_STATUS" != "running" ]; then
+            echo -e "${RED}❌ Service $SERVICE is not running (status: $CONTAINER_STATUS)${NC}"
+            ALL_RUNNING=false
+        else
+            echo -e "${GREEN}✓ Service $SERVICE is running${NC}"
+
+            # Check logs for errors
+            ERROR_LOGS=$(docker-compose logs $SERVICE | grep -i "error\|exception\|fatal" | wc -l)
+            if [ $ERROR_LOGS -gt 0 ]; then
+                echo -e "${YELLOW}  ⚠ Found $ERROR_LOGS potential errors in logs${NC}"
+            else
+                echo -e "${GREEN}  ✓ No errors found in logs${NC}"
+            fi
+        fi
+    fi
+done
+
+# Cleanup - tear down containers after test
+echo -e "${YELLOW}Cleaning up...${NC}"
+docker-compose down
+
+if [ "$ALL_RUNNING" = true ]; then
+    echo -e "${GREEN}==== All services are running successfully! ====${NC}"
+    exit 0
+else
+    echo -e "${RED}==== Some services failed to start properly. ====${NC}"
+    exit 1
+fi


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to test Docker Compose setups and includes a test script to verify the Docker Compose configuration. The most important changes are the addition of the workflow configuration file and the test script.

New GitHub Actions workflow:

* [`.github/workflows/docker-compose-test.yml`](diffhunk://#diff-827e0fc5da03873b4e4ca57e9d6cc4c35b972ee1cb3284e55c8ec785fa84f4b2R1-R39): Added a new GitHub Actions workflow to test Docker Compose setups on pull requests to the `main` and `dev` branches. This workflow checks out the code, sets up Docker Buildx, installs Docker Compose, runs the Docker Compose test script, and uploads logs if there is a failure.

Test script for Docker Compose:

* [`test-docker-compose.sh`](diffhunk://#diff-d12c112a411cee778b2c3ce50067939cb9e8b44cadccae2fcfc03cd5187ecb2bR1-R78): Added a new test script to verify the Docker Compose setup. The script checks for the installation of Docker and Docker Compose, verifies the existence of the `docker-compose.yaml` file, starts Docker Compose services, checks their status, inspects logs for errors, and cleans up the containers after the test.