### PR TITLE
Hardcode container name for clarity

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
   trip-management:
     build: .
-    container_name: ${SERVICE_NAME}
-    depends_on: 
+    container_name: trip-management
+    depends_on:
       - mongo-trip
     environment:
       - ENV_VAR=example


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yaml` file. The change involves hardcoding the container name for the `trip-management` service instead of using the `${SERVICE_NAME}` environment variable.

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L4-R4): Changed the `container_name` for the `trip-management` service from `${SERVICE_NAME}` to `trip-management`.