### PR TITLE
Change env name to match azure standards

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -2,6 +2,11 @@ services:
   trip-management:
     ports:
       - "8080:8080"
+    volumes:
+      - .:/app
   mongo-trip:
     ports:
       - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,13 +6,8 @@ services:
       - mongo-trip
     environment:
       - ENV_VAR=example
-    volumes:
-      - .:/app
   mongo-trip:
       image: mongo
       restart: always
       ports:
         - 27017:27017
-      environment:
-        MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
-        MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}


### PR DESCRIPTION
This pull request includes updates to the `docker-compose.override.yaml` and `docker-compose.yaml` files to adjust the volumes and environment configurations for the `trip-management` and `mongo-trip` services.

Configuration updates:

* [`docker-compose.override.yaml`](diffhunk://#diff-5cf196bb28f864c2149668ce0fc575489e4446710d79129f3d8cece2639ef6c3R5-R12): Added volume mapping for `trip-management` service and environment variables for `mongo-trip` service.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L9-L18): Removed volume mapping for `trip-management` service and environment variables for `mongo-trip` service.