### PR TITLE
associate trips to users and show them in the ui

### DIFF
--- a/app/routes/trip_router.py
+++ b/app/routes/trip_router.py
@@ -74,6 +74,20 @@ async def trip_creation(forms: Form):
         await redis_client.set(
             str(documentID), json.dumps(itinerary.model_dump()), expire=3600
         )
+        
+        # save at supabase
+        try:
+            user_id = 50  # Hardcoded user ID for now
+            user_trip_response = request.post(
+                f"http://user-management:8080/trips/",
+                params={"trip_id": str(documentID), "user_id": user_id},
+                timeout=10
+            )
+            print(f"User-trip association response: {user_trip_response.status_code} - {user_trip_response.text}")
+        except Exception as user_trip_error:
+            print(f"Error associating user with trip: {str(user_trip_error)}")
+            # Continue execution even if user association fails
+            
         return ResponseBody(
             {"tripId": str(documentID), "itinerary": itinerary.model_dump()},
             "Trips created",

--- a/app/routes/trip_router.py
+++ b/app/routes/trip_router.py
@@ -75,9 +75,11 @@ async def trip_creation(forms: Form):
             str(documentID), json.dumps(itinerary.model_dump()), expire=3600
         )
         
-        # save at supabase
+        # Call user-management service to associate user with trip
         try:
+            print("user id: ", user_id)
             user_id = 50  # Hardcoded user ID for now
+            print("user id: ", user_id)
             user_trip_response = request.post(
                 f"http://user-management:8080/trips/",
                 params={"trip_id": str(documentID), "user_id": user_id},
@@ -87,6 +89,15 @@ async def trip_creation(forms: Form):
         except Exception as user_trip_error:
             print(f"Error associating user with trip: {str(user_trip_error)}")
             # Continue execution even if user association fails
+        
+        # Save the trip to MongoDB, this is for testing purposes, cache should probably be used instead along with the save_trip
+        try:
+            client = DBClient()
+            save_result = client.post_trip([itinerary], [str(documentID)])
+            print(f"Trip saved to MongoDB: {save_result}")
+        except Exception as save_error:
+            print(f"Error saving trip to MongoDB: {str(save_error)}")
+            # Continue execution even if saving fails
             
         return ResponseBody(
             {"tripId": str(documentID), "itinerary": itinerary.model_dump()},


### PR DESCRIPTION

### New functionality added:

* **User-trip association:**
  - A request is sent to the user-management service to associate the user with the newly created trip. This includes a hardcoded `user_id` (currently set to 50) and logs the response from the service. Errors during this process are caught and logged without interrupting the function.

* **Trip saving to MongoDB:**
  - Added logic to save the trip to MongoDB using the `DBClient` class. This is primarily for testing purposes, with a note suggesting that caching might be a better alternative in the future. Errors during this process are also caught and logged without halting execution.