### PR TITLE
Voyage 169 save itinerary on db

### DIFF
--- a/app/database/MongoClient.py
+++ b/app/database/MongoClient.py
@@ -71,6 +71,12 @@ class DBClient:
         except Exception as e:
             return f"Error updating trip: {e}"
 
+    def delete_trip(self,id:str):
+        try:
+            result= self.collection.delete_one({"_id":ObjectId(id)})
+            return result==1
+        except Exception as e:
+            return f"Error updating trip: {e}"
     def delete_place_from_trip(self, trip_id: str, place_id: str):
         try:
             result = self.collection.update_one(


### PR DESCRIPTION
Slight changes to the trip management service on the save trip endpoint. 
The saving of the trip is to be executed on the save endpoint instead of the "/trips" endpoint.
Added a mongo client to delete the trip if there were to be any errors on the insertion on the supabase table.
Also making the forward of the cookie to identify the user on the user-managment with the previously made middleware.