### PR TITLE
Voyage 228 trip saving not working properly in dev and not at all in prod

### DIFF
--- a/app/routes/trip_router.py
+++ b/app/routes/trip_router.py
@@ -113,6 +113,7 @@ async def save_trip(trip: TripSaveRequest, rq: Request):
         try:
             print(trip.id)
             existing_trip = client.get_trip_by_id(str(trip.id))
+            print("Existing trip:", existing_trip)
             if existing_trip is not None:
                 already_exists = True
                 print("Trip already exists in the database.")

--- a/app/schemas/forms_schema.py
+++ b/app/schemas/forms_schema.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List,Dict,Any, Optional
+from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 from enum import Enum
 
@@ -37,20 +37,21 @@ class Road(BaseModel):
 class Place(BaseModel):
     coordinates: LatLong
     place_name: str
+    place_id: Optional[str] = None
 
 
 class Zone(BaseModel):
-    center:LatLong
-    radius:int
+    center: LatLong
+    radius: int
+
 
 class Form(BaseModel):
-    budget:float
-    dateStart:datetime
-    display_name:str
-    duration:int # duration in days
-    tripType:TripType
+    budget: float
+    dateStart: datetime
+    display_name: str
+    duration: int  # duration in days
+    tripType: TripType
     data_type: Place | Zone | Road
-    users:List[str]
-    questions:Dict[str,List[Question]]
-
-
+    users: List[str]
+    questions: Dict[str, List[Question]]
+    must_visit_places: Optional[List[Place]] = None

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,5 +16,3 @@ services:
   mongo-trip:
       image: mongo
       restart: always
-      ports:
-        - 27017:27017


### PR DESCRIPTION
This pull request introduces significant improvements to the `MongoClient` class for thread safety and singleton behavior, adds support for `must_visit_places` in trip creation, and includes debugging enhancements. It also removes an unused database port mapping in the Docker configuration.

### Database Enhancements:

* Implemented a thread-safe singleton pattern in the `DBClient` class to ensure only one instance is created across threads (`app/database/MongoClient.py`).
* Modified the MongoDB connection string to include `authSource=admin` for improved authentication handling (`app/database/MongoClient.py`).

### Trip Creation Enhancements:

* Added support for a `must_visit_places` field in the `Form` schema, allowing users to specify must-visit locations during trip creation (`app/schemas/forms_schema.py`, `app/routes/trip_router.py`). [[1]](diffhunk://#diff-e65bf591d1bb1c2a0de1131c5e20788633b4eda01622b6614a03b3d47cdf0662L55-R57) [[2]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR42-R57) [[3]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR66)

### Debugging Improvements:

* Added print statements to log key variables and errors for better debugging during trip creation and retrieval (`app/database/MongoClient.py`, `app/routes/trip_router.py`). [[1]](diffhunk://#diff-08aa6fe18b344bb371c7c1039537c2cb66b33d80d608b59174dcf152236cb0c5R79-R89) [[2]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR116)

### Code Cleanup:

* Removed an unused method `get_trip_by_id` from the `DBClient` class, as it was redundant with an existing method (`app/database/MongoClient.py`).

### Configuration Changes:

* Removed the exposed port mapping for MongoDB in the `docker-compose.yaml` file to enhance security by limiting external access (`docker-compose.yaml`).