### PR TITLE
VOYAGE-209-Keywords-feature

### DIFF
--- a/app/schemas/forms_schema.py
+++ b/app/schemas/forms_schema.py
@@ -1,22 +1,26 @@
 from datetime import datetime 
 from typing import List,Dict,Any, Annotated,Union,Literal,Optional
-from app.schemas.trips_schema import PlaceInfo
+from app.schemas.trips_schema import PlaceInfo, MustVisitPlace
 from pydantic import BaseModel,Field
 from enum import Enum
 
 
-class QuestionType(Enum):
+class QuestionType(str, Enum):
     SCALE = "scale"
     SELECT = "select"
 
 
 class Question(BaseModel):
     question_id: int
-    value: Any
+    value: Optional[int]
     type: QuestionType
 
     class Config:
         use_enum_values = True
+
+
+class UserQuestions(BaseModel):
+    questions: List[Question]
 
 
 class TripType(Enum):
@@ -47,12 +51,12 @@ class Zone(BaseModel):
     radius: int
 
 class Form(BaseModel):
-    budget:float
-    dateStart:datetime
-    display_name:str
-    duration:int # duration in days
-    tripType:TripType
-    data_type: Union[Road, Place, Zone] = Field(discriminator="type")  # This tells Pydantic to use the 'type' field
-    users:List[str]
-    questions:Dict[str,List[Question]]
-    must_visit_places: Optional[List[Place]] = None
+    budget: float
+    startDate: str
+    duration: int = 3
+    questions: Dict[str, List[Question]]
+    must_visit_places: List[MustVisitPlace] = []
+    keywords: List[str] = []
+    tripType: TripType
+    display_name: str
+    data_type: Union[Zone, Place, Road] = Field(discriminator="type")

--- a/app/schemas/trips_schema.py
+++ b/app/schemas/trips_schema.py
@@ -25,6 +25,12 @@ class PlaceInfo(BaseModel):
     good_for_groups: Optional[bool] = None
 
 
+class MustVisitPlace(BaseModel):
+    place_name: str
+    coordinates: LatLong
+    place_id: Optional[str] = None
+
+
 class Activity(BaseModel):
     id: int
     place: PlaceInfo


### PR DESCRIPTION
This pull request introduces several updates to improve date handling, enhance schema definitions, and ensure better default values in the trip creation process. Key changes include adding robust error handling for date parsing, introducing new schema models, and refining existing fields to improve clarity and functionality.

### Improvements to date handling:
* [`app/routes/trip_router.py`](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR60-L74): Added error handling for `startDate` parsing to ensure invalid formats default to the current date. Updated logic to handle ISO 8601 strings with or without the `Z` timezone.
* [`app/routes/trip_router.py`](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dL41-R43): Ensured the trip duration is at least one day by using the `max` function to validate the `duration` field.

### Enhancements to schema definitions:
* [`app/schemas/forms_schema.py`](diffhunk://#diff-146d42518513b1c1b9dddc07c770f910207f5c2d7514c232c27b53c76cb160d7R28-R33): Added a new `MustVisitPlace` model to represent must-visit places with attributes like `place_name`, `coordinates`, and an optional `place_id`.
* [`app/schemas/forms_schema.py`](diffhunk://#diff-e65bf591d1bb1c2a0de1131c5e20788633b4eda01622b6614a03b3d47cdf0662L51-R62): Updated the `Form` model to include new fields like `keywords` (defaulting to an empty list) and `must_visit_places` (defaulting to an empty list). Changed `dateStart` to `startDate` as a string for consistency with the input format.

### Refinements to existing models:
* [`app/schemas/forms_schema.py`](diffhunk://#diff-e65bf591d1bb1c2a0de1131c5e20788633b4eda01622b6614a03b3d47cdf0662L3-R25): Modified the `QuestionType` enum to inherit from `str` for better JSON serialization. Updated the `Question` model to make the `value` field optional.