### PR TITLE
VOYAGE-238-Add-information-required-for-statistics-to-trip

### DIFF
--- a/app/schemas/forms_schema.py
+++ b/app/schemas/forms_schema.py
@@ -59,4 +59,6 @@ class Form(BaseModel):
     keywords: List[str] = []
     tripType: TripType
     display_name: str
+    country: str | None = None
+    city: str | None = None
     data_type: Union[Zone, Place, Road] = Field(discriminator="type")

--- a/app/schemas/trips_schema.py
+++ b/app/schemas/trips_schema.py
@@ -59,6 +59,8 @@ class Trip(BaseModel):
     days: List[Day] = []
     name: str
     trip_type:Optional[str]
+    country:str | None = None
+    city:str | None = None
 
 class Stop(BaseModel):
     place:PlaceInfo
@@ -71,6 +73,8 @@ class RoadItinerary(BaseModel):
     routes:List[Route]
     suggestions:List[PlaceInfo]
     trip_type:Optional[str]
+    country:str | None = None
+    city:str | None = None
 
 class TripResponse(BaseModel):
     itinerary: Trip | RoadItinerary

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,3 +16,8 @@ services:
   mongo-trip:
       image: mongo
       restart: always
+      volumes:
+        - mongo_data:/data/db
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
This pull request introduces enhancements to the trip management functionality, including support for storing country and city details in trip-related models, and updates to the `docker-compose.yaml` file to persist MongoDB data. The most important changes are grouped below by theme.

### Trip Management Enhancements:

* **Added `country` and `city` fields to the `Form` model** in `app/schemas/forms_schema.py` to capture additional trip metadata during trip creation. These fields are optional.
* **Extended trip-related models (`Trip` and `RoadItinerary`)** in `app/schemas/trips_schema.py` to include `country` and `city` fields, ensuring that these details are part of the itinerary data. [[1]](diffhunk://#diff-146d42518513b1c1b9dddc07c770f910207f5c2d7514c232c27b53c76cb160d7R62-R63) [[2]](diffhunk://#diff-146d42518513b1c1b9dddc07c770f910207f5c2d7514c232c27b53c76cb160d7R76-R77)
* **Updated `trip_creation` function** in `app/routes/trip_router.py` to handle `country` and `city` fields by extracting them from the `Form` object and including them in the itinerary and request payload. [[1]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR34-R35) [[2]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR86-R87) [[3]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR106-R107)
* **Modified `save_trip` function** in `app/routes/trip_router.py` to ensure `country` and `city` fields are added to the itinerary before saving.

### Infrastructure Updates:

* **Added a persistent volume for MongoDB in `docker-compose.yaml`** to ensure database data is retained across container restarts.

### Bug Fix:

* **Fixed response handling in `get_trip` function** in `app/routes/trip_router.py` by converting the result to a dictionary using `model_dump()` to ensure consistent data serialization.