### PR TITLE
VOYAGE-231-Consume-the-user-invitations-for-group-trips-in-the-frontend

### DIFF
--- a/app/routes/trip_router.py
+++ b/app/routes/trip_router.py
@@ -72,6 +72,7 @@ async def trip_creation(forms: Form):
             "keywords": forms.keywords,
             "country": country,
             "city": city,
+            "is_group": forms.is_group,
         }
 
         requestBody["data"] = forms.data_type.model_dump()
@@ -133,6 +134,7 @@ async def save_trip(trip: TripSaveRequest, rq: Request):
         trip.itinerary.trip_type=trip.trip_type
         trip.itinerary.country=trip.itinerary.country
         trip.itinerary.city=trip.itinerary.city
+        trip.itinerary.is_group=trip.is_group
         result = client.post_trip([trip.itinerary], [trip.id])
         if len(result) != 0:
             # forwarding the authentication cookie
@@ -143,7 +145,10 @@ async def save_trip(trip: TripSaveRequest, rq: Request):
                 print("Trip created")
                 user_trip_response = request.post(
                     f"http://user-management:8080/trips/save",
-                    params={"trip_id": str(trip.id)},
+                    json={
+                        "trip_id": str(trip.id),
+                        "is_group": bool(trip.is_group)
+                            },
                     cookies={"voyage_at": voyage_cookie} if voyage_cookie else None,
                     timeout=10,
                 )

--- a/app/schemas/forms_schema.py
+++ b/app/schemas/forms_schema.py
@@ -61,3 +61,4 @@ class Form(BaseModel):
     country: str | None = None
     city: str | None = None
     data_type: Union[Zone, Place, Road] = Field(discriminator="type")
+    is_group: bool

--- a/app/schemas/trips_schema.py
+++ b/app/schemas/trips_schema.py
@@ -51,30 +51,33 @@ class Trip(BaseModel):
     end_date: datetime | str
     days: List[Day] = []
     name: str
-    trip_type:Optional[str]
-    country:str | None = None
-    city:str | None = None
+    trip_type: Optional[str]
+    country: str | None = None
+    city: str | None = None
+    is_group: bool
 
 class Stop(BaseModel):
-    place:PlaceInfo
-    index:int
-    id:str
+    place: PlaceInfo
+    index: int
+    id: str
 
 class RoadItinerary(BaseModel):
-    name:str
-    stops:List[Stop]
-    routes:List[Route]
-    suggestions:List[PlaceInfo]
-    trip_type:Optional[str]
-    country:str | None = None
-    city:str | None = None
+    name: str
+    stops: List[Stop]
+    routes: List[Route]
+    suggestions: List[PlaceInfo]
+    trip_type: Optional[str]
+    country: str | None = None
+    city: str | None = None
+    is_group: bool
 
 class TripResponse(BaseModel):
     itinerary: Trip | RoadItinerary
-    tripId:str
+    tripId: str
 
 class TripSaveRequest(BaseModel):
     id: str
-    itinerary:Trip | RoadItinerary
-    trip_type:str
+    itinerary: Trip | RoadItinerary
+    trip_type: str
+    is_group: bool
 


### PR DESCRIPTION
This pull request introduces a new `is_group` field across multiple components of the trip management system to support group trip functionality. The changes ensure that the `is_group` attribute is properly handled in the API, schemas, and data processing logic.

### API Updates:
* Added the `is_group` field to the trip creation payload in `trip_creation` and included it in the trip save request payload in `save_trip`. This ensures that group trip information is passed through API requests. [[1]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR75) [[2]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dR137) [[3]](diffhunk://#diff-3a2867233b3a00ee13f2d24ce6e5209c71440ceee65553766f982f47b6a6a62dL146-R151)

### Schema Updates:
* Added the `is_group` field to the `Form` schema in `forms_schema.py` to capture group trip information during form submission.
* Updated the `Trip`, `RoadItinerary`, and `TripSaveRequest` schemas in `trips_schema.py` to include the `is_group` field, enabling proper representation of group trip data in the system. [[1]](diffhunk://#diff-146d42518513b1c1b9dddc07c770f910207f5c2d7514c232c27b53c76cb160d7R57) [[2]](diffhunk://#diff-146d42518513b1c1b9dddc07c770f910207f5c2d7514c232c27b53c76cb160d7R72) [[3]](diffhunk://#diff-146d42518513b1c1b9dddc07c770f910207f5c2d7514c232c27b53c76cb160d7R82)