### PR TITLE
Create Preferences

### DIFF
--- a/app/schemas/forms_schema.py
+++ b/app/schemas/forms_schema.py
@@ -17,11 +17,6 @@ class Question(BaseModel):
     class Config:
         use_enum_values = True
 
-
-class UserQuestions(BaseModel):
-    questions: List[Question]
-
-
 class TripType(Enum):
     PLACE = "place"
     ROAD = "road"
@@ -49,11 +44,15 @@ class Zone(BaseModel):
     center: LatLong
     radius: int
 
+class Preferences(BaseModel):
+    questions:List[Question]
+    preferencesName:Optional[str] = None
+
 class Form(BaseModel):
     budget: float
     startDate: str
     duration: int = 3
-    questions: Dict[str, List[Question]]
+    preferences: Preferences
     must_visit_places: List[PlaceInfo] = []
     keywords: List[str] = []
     tripType: TripType

--- a/app/schemas/trips_schema.py
+++ b/app/schemas/trips_schema.py
@@ -79,5 +79,6 @@ class TripSaveRequest(BaseModel):
     id: str
     itinerary: Trip | RoadItinerary
     trip_type: str
+    preferences_id:int
     is_group: bool
 

--- a/app/schemas/trips_schema.py
+++ b/app/schemas/trips_schema.py
@@ -74,11 +74,11 @@ class RoadItinerary(BaseModel):
 class TripResponse(BaseModel):
     itinerary: Trip | RoadItinerary
     tripId: str
+    preferences_id:Optional[int]=None
 
 class TripSaveRequest(BaseModel):
     id: str
     itinerary: Trip | RoadItinerary
     trip_type: str
-    preferences_id:int
     is_group: bool
 


### PR DESCRIPTION
# Summary of Changes: `VOYAGE-253-Create-preferences-Profile` vs `dev`

## New Features

### 1. Preferences Integration with Trip Creation

- **Trip Creation (`app/routes/trip_router.py` and `app/routes/websocket_router.py`):**
  - During trip creation, user preferences are now extracted from `forms.preferences` instead of per-user questions.
  - If a user is logged in (via `voyage_at` cookie), the preferences are sent to the user-management service (`POST /preferences`).
  - The returned `preferences_id` from the user-management service is saved in the trip data.
  - Improved error handling for failed preferences submissions to the user-management service.

### 2. Schema Updates

- **Form Schema (`app/schemas/forms_schema.py`):**
  - Introduces `Preferences` model with `questions` (list of `Question`) and `preferencesName`.
  - The `Form` model now contains a `preferences` field (instead of a `questions` dict per user).

- **Trip Response Schema (`app/schemas/trips_schema.py`):**
  - `TripResponse` now includes an optional `preferences_id` field to track associated preferences.

## Refactoring & Cleanups

- **Removed:** `UserQuestions` model (no longer needed due to the new preferences structure).
- **Refactored:** Trip creation code to use new preferences structure and to remove legacy/question-per-user logic.
- **Removed:** Redundant debug prints and comments in trip creation endpoints.

---

## Summary Table

| File                              | Change Type | Description                                                         |
|------------------------------------|-------------|---------------------------------------------------------------------|
| `app/routes/trip_router.py`        | Modified    | Integrates preferences into trip creation, posts to user-management |
| `app/routes/websocket_router.py`   | Modified    | Same as above for websocket-based trip creation                     |
| `app/schemas/forms_schema.py`      | Modified    | New Preferences model, Form model update, removed UserQuestions     |
| `app/schemas/trips_schema.py`      | Modified    | Added preferences_id to TripResponse                                |

---

## Impact

- Trip creation (via REST and WebSocket) now supports saving and associating user preferences.
- All forms and APIs are aligned to use a single preferences structure, simplifying data flow.
- The user-management microservice is now a dependency for trip preference storage.
