### PR TITLE
Fix duplicates from must visit places

### DIFF
--- a/app/schemas/trips_schema.py
+++ b/app/schemas/trips_schema.py
@@ -1,6 +1,6 @@
 from datetime import datetime 
 from typing import List, Optional, Dict
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 
 class LatLong(BaseModel):
     latitude: float
@@ -28,6 +28,18 @@ class PlaceInfo(BaseModel):
     allows_dogs: Optional[bool] = None
     good_for_children: Optional[bool] = None
     good_for_groups: Optional[bool] = None
+
+    @root_validator(pre=True)
+    def handle_place_id_field(cls, values):
+        """Handle both 'id' and 'place_id' fields from different sources"""
+        if isinstance(values, dict):
+            # If id is None or missing, try to use place_id
+            if values.get('id') is None and 'place_id' in values:
+                values['id'] = values['place_id']
+        return values
+    
+    class Config:
+        extra = "ignore"  # Ignore extra fields like 'place_id'
 
 class Activity(BaseModel):
     id: int


### PR DESCRIPTION
This pull request introduces a new `root_validator` to the `PlaceInfo` class in `app/schemas/trips_schema.py` to handle discrepancies between `id` and `place_id` fields from different data sources. It also updates the `PlaceInfo` class configuration to ignore extra fields.

### Changes to `PlaceInfo` class:

* **Added `root_validator` for field handling**: Introduced a `root_validator` to ensure that the `id` field is populated using the `place_id` field if `id` is missing or `None`. This ensures compatibility with data sources that use different field names.
* **Updated `Config` to ignore extra fields**: Configured the `PlaceInfo` class to ignore extra fields like `place_id` that are not explicitly defined in the schema.

### General schema updates:

* **Imported `root_validator`**: Added the `root_validator` import from Pydantic in `app/schemas/trips_schema.py` to support the new validation logic.